### PR TITLE
Incresing AudioFeeder buffer size to enable playing audios in background

### DIFF
--- a/Classes/OGVAudioFeeder.m
+++ b/Classes/OGVAudioFeeder.m
@@ -107,7 +107,7 @@ static void OGVAudioFeederPropListener(void *data, AudioQueueRef queue, AudioQue
         samplesPlayed = 0;
         
         sampleSize = sizeof(Float32);
-        bufferSize = 1024;
+        bufferSize = 2048;
         bufferByteSize = bufferSize * sampleSize * format.channels;
 
         circularBuffer = (Float32 *)malloc(circularBufferSize * sampleSize * format.channels);


### PR DESCRIPTION
This pull request will fix #170.
The issue was when the user presses the lock button, the app wouldn't have enough buffer size to keep playing, thus the audio would freeze until the user turned the screen on again